### PR TITLE
Remove HTML tags from bible.org responses

### DIFF
--- a/app/Commands/Bless.hs
+++ b/app/Commands/Bless.hs
@@ -48,6 +48,7 @@ bless' i = do
             $ setRequestMethod "GET"
             $ setRequestQueryString [ ("passage", Just $ encodeUtf8 "random")
                                     , ("type", Just $ encodeUtf8 "json")
+                                    , ("formatting", Just $ encodeUtf8 "plain")
                                     ]
             $ setRequestIgnoreStatus
             defReq


### PR DESCRIPTION
By default bible.org returns entries with <b> </b> tags if they have them. 

This query parameter tells it to just return the text without tags.